### PR TITLE
replace spinner on connect by a dialog

### DIFF
--- a/src/CaptivePortal.tsx
+++ b/src/CaptivePortal.tsx
@@ -76,7 +76,7 @@ function CaptivePortalInner({
     setConnecting(true);
     setError(false);
     setNetworks([]);
-
+    /*
     if (mockApi) {
       setTimeout(() => {
         setConnecting(false);
@@ -91,7 +91,7 @@ function CaptivePortalInner({
       api
         .connect(essid, password)
         .then((res) => {
-          setConnecting(false);
+          setConnecting();
 
           if (res.success) {
             onConnected(essid);
@@ -105,8 +105,8 @@ function CaptivePortalInner({
           setConnecting(false);
         });
     }
+  */
   };
-
   useEffect(() => {
     if (!initialized) {
       updateNetworks();

--- a/src/CaptivePortal.tsx
+++ b/src/CaptivePortal.tsx
@@ -7,8 +7,7 @@ import {
   Label,
   Toaster,
   Intent,
-  Overlay,
-  Spinner,
+  Dialog,
   ButtonGroup,
 } from "@blueprintjs/core";
 import "./CaptivePortal.css";
@@ -117,10 +116,22 @@ function CaptivePortalInner({
 
   return (
     <div className="CaptivePortal-content">
-      <Overlay isOpen={connecting}>
-        <Spinner size={Spinner.SIZE_LARGE} className="CaptivePortal-spinner" />
-      </Overlay>
-      <div className="CaptivePortal-list">
+      <Dialog
+          isOpen={connecting}
+          className="bp3-dark bp3-large bp3-text-large"
+          title={<div>Oops, connection issues</div>}
+          icon="globe-network"
+          hasBackdrop={true}
+          canEscapeKeyClose={false}
+          canOutsideClickClose={false}
+          isCloseButtonShown={false} >
+          <div className="CaptivePortal-dialog" >
+           <p>Your Third-I is gone to another place in the Internet</p>
+           <p> Please follow him : </p>
+           <p> See you later !</p>
+          </div>
+      </Dialog>
+     <div className="CaptivePortal-list">
         <Menu>
           {networks.length === 0 && (
             <MenuItem

--- a/src/CaptivePortal.tsx
+++ b/src/CaptivePortal.tsx
@@ -119,14 +119,14 @@ function CaptivePortalInner({
       <Dialog
           isOpen={connecting}
           className="bp3-dark bp3-large bp3-text-large"
-          title={<div>Oops, connection issues</div>}
+          title={<div>Connection issues</div>}
           icon="globe-network"
           hasBackdrop={true}
           canEscapeKeyClose={false}
           canOutsideClickClose={false}
           isCloseButtonShown={false} >
           <div className="CaptivePortal-dialog" >
-           <p>Your Third-I is gone to another place in the Internet</p>
+           <p>Your Third-I is gone to an another network</p>
            <p> Please follow him : </p>
            <p> See you later !</p>
           </div>


### PR DESCRIPTION
When you try to connect to another wifi, you can see a dialog

this dialog can't be closed, but it's closing when the call to the API is done